### PR TITLE
a few cosmetic changes to silkscreen

### DIFF
--- a/mta100/__main__.py
+++ b/mta100/__main__.py
@@ -106,10 +106,11 @@ def make_640455(partno, positions, l, w=None, g=None):
         Line('F.Fab', [0, 6.35], [0, 0], width=0.1),
         Rect('F.CrtYd', [-cmargin, -moffset - cmargin], [l + cmargin, ph + cmargin - (moffset / 2)], width=0.05),
 
-        # Line('F.SilkS', [-smargin, -smargin], [l + smargin, -smargin]),
-        # Line('F.SilkS', [l + smargin, -smargin], [l + smargin, 6.35 + smargin]),
-        # Line('F.SilkS', [l + smargin, 6.35 + smargin], [-smargin, 6.35 + smargin]),
-        # Line('F.SilkS', [-smargin, 6.35 + smargin], [-smargin, -smargin]),
+        Line('F.SilkS', [-smargin, -smargin], [l + smargin - 1, -smargin]),
+        Line('F.SilkS', [l + smargin - 1, -smargin], [l + smargin, 1 - smargin]),
+        Line('F.SilkS', [l + smargin, 1 - smargin], [l + smargin, 6.35 + smargin]),
+        Line('F.SilkS', [l + smargin, 6.35 + smargin], [-smargin, 6.35 + smargin]),
+        Line('F.SilkS', [-smargin, 6.35 + smargin], [-smargin, -smargin]),
     ]
 
     th = 2.87 - 0.64 - (0.64 / 2)
@@ -127,6 +128,7 @@ def make_640455(partno, positions, l, w=None, g=None):
         shapes.append(Pad(pin, [left, -2.985], 1.85, 1.1))
         if pos == 0:
             origin = shapes[-1].center
+        shapes.append(Line('F.SilkS', [left, -1.8], [left, 0]))
 
     salt = 0
     for shape in shapes:

--- a/mta100/__main__.py
+++ b/mta100/__main__.py
@@ -6,23 +6,12 @@ from hashlib import sha256
 
 from sexpdata import Symbol, dumps
 
-from mta100.shape import Rect, PadRect, Line, Pad
+from mta100.shape import Rect, PadRect, Line, Pad, make_connected_lines, make_indexed_rect
 
 
 def make_uuid(name, index):
     h = hmac.new(name.encode(), str(index).encode(), digestmod=sha256)
     return str(uuid.UUID(bytes=h.digest()[:16], version=4))
-
-
-def make_indexed_rect(layer, start, end):
-    result = [
-        Line('F.Fab', [0, 0], [l - 1, 0], width=0.1),
-        Line('F.Fab', [l - 1, 0], [l, 1], width=0.1),
-        Line('F.Fab', [l, 1], [l, 6.35], width=0.1),
-        Line('F.Fab', [l, 6.35], [0, 6.35], width=0.1),
-        Line('F.Fab', [0, 6.35], [0, 0], width=0.1),
-    ]
-    return result
 
 
 def make_647050(partno, positions, l, w=None, g=None):
@@ -43,19 +32,26 @@ def make_647050(partno, positions, l, w=None, g=None):
     smargin = 0.1
     ph = 7.62
     moffset = (ph - 6.35)
-    shapes = [
-        Line('F.Fab', [0, 0], [l - 1, 0], width=0.1),
-        Line('F.Fab', [l - 1, 0], [l, 1], width=0.1),
-        Line('F.Fab', [l, 1], [l, 6.35], width=0.1),
-        Line('F.Fab', [l, 6.35], [0, 6.35], width=0.1),
-        Line('F.Fab', [0, 6.35], [0, 0], width=0.1),
-        Rect('F.CrtYd', [-cmargin, -moffset - cmargin], [l + cmargin, ph + cmargin - (moffset / 2)], width=0.05),
 
-        Line('F.SilkS', [-smargin, -smargin], [l + smargin, -smargin]),
-        Line('F.SilkS', [l + smargin, -smargin], [l + smargin, 6.35 + smargin]),
-        Line('F.SilkS', [l + smargin, 6.35 + smargin], [-smargin, 6.35 + smargin]),
-        Line('F.SilkS', [-smargin, 6.35 + smargin], [-smargin, -smargin]),
-    ]
+    shapes = make_connected_lines(
+        'F.Fab', [
+            [0, 0],
+            [l - 1, 0],
+            [l, 1],
+            [l, 6.35],
+            [0, 6.35],
+        ], width=0.1, loop=True
+    ) + [
+        Rect('F.CrtYd', [-cmargin, -moffset - cmargin], [l + cmargin, ph + cmargin - (moffset / 2)], width=0.05),
+    ] + make_connected_lines(
+        'F.SilkS', [
+            [-smargin, -smargin],
+            [l + smargin, -smargin],
+            [l + smargin, 6.35 + smargin],
+            [-smargin, 6.35 + smargin],
+        ], loop=True
+    )
+
 
     th = 2.87 - 0.64 - (0.64 / 2)
     if g is None:
@@ -100,20 +96,21 @@ def make_640455(partno, positions, l, w=None, g=None):
     moffset = (ph - 6.35)
     origin = [0, 0]
     sloped_margin = smargin * math.tan(math.pi / 16.0)
-    shapes = [
-        Line('F.Fab', [0, 0], [l - 1, 0], width=0.1),
-        Line('F.Fab', [l - 1, 0], [l, 1], width=0.1),
-        Line('F.Fab', [l, 1], [l, 6.35], width=0.1),
-        Line('F.Fab', [l, 6.35], [0, 6.35], width=0.1),
-        Line('F.Fab', [0, 6.35], [0, 0], width=0.1),
+    shapes = make_connected_lines(
+        'F.Fab', [
+            [0, 0], [l-1, 0], [l, 1], [l, 6.35], [0, 6.35]
+        ], width=0.1, loop=True
+    ) + [
         Rect('F.CrtYd', [-cmargin, -moffset - cmargin], [l + cmargin, ph + cmargin - (moffset / 2)], width=0.05),
-
-        Line('F.SilkS', [-smargin, -smargin], [l - 1 + sloped_margin, -smargin]),
-        Line('F.SilkS', [l - 1 + sloped_margin, -smargin], [l + smargin, 1 - sloped_margin]),
-        Line('F.SilkS', [l + smargin, 1 - sloped_margin], [l + smargin, 6.35 + smargin]),
-        Line('F.SilkS', [l + smargin, 6.35 + smargin], [-smargin, 6.35 + smargin]),
-        Line('F.SilkS', [-smargin, 6.35 + smargin], [-smargin, -smargin]),
-    ]
+    ] + make_connected_lines(
+        'F.SilkS', [
+            [-smargin, -smargin],
+            [l - 1 + sloped_margin, -smargin],
+            [l + smargin, 1 - sloped_margin],
+            [l + smargin, 6.35 + smargin],
+            [-smargin, 6.35 + smargin],
+        ], loop=True
+    )
 
     th = 2.87 - 0.64 - (0.64 / 2)
     if g is None:

--- a/mta100/__main__.py
+++ b/mta100/__main__.py
@@ -32,6 +32,7 @@ def make_647050(partno, positions, l, w=None, g=None):
     smargin = 0.1
     ph = 7.62
     moffset = (ph - 6.35)
+    sloped_margin = smargin * math.tan(math.pi / 16.0)
 
     shapes = make_connected_lines(
         'F.Fab', [
@@ -46,7 +47,8 @@ def make_647050(partno, positions, l, w=None, g=None):
     ] + make_connected_lines(
         'F.SilkS', [
             [-smargin, -smargin],
-            [l + smargin, -smargin],
+            [l - 1 + sloped_margin, -smargin],
+            [l + smargin, 1 - sloped_margin],
             [l + smargin, 6.35 + smargin],
             [-smargin, 6.35 + smargin],
         ], loop=True

--- a/mta100/__main__.py
+++ b/mta100/__main__.py
@@ -1,6 +1,7 @@
 import hmac
 import os
 import uuid
+import math
 from hashlib import sha256
 
 from sexpdata import Symbol, dumps
@@ -98,6 +99,7 @@ def make_640455(partno, positions, l, w=None, g=None):
     ph = 7.62
     moffset = (ph - 6.35)
     origin = [0, 0]
+    sloped_margin = smargin * math.tan(math.pi / 16.0)
     shapes = [
         Line('F.Fab', [0, 0], [l - 1, 0], width=0.1),
         Line('F.Fab', [l - 1, 0], [l, 1], width=0.1),
@@ -106,9 +108,9 @@ def make_640455(partno, positions, l, w=None, g=None):
         Line('F.Fab', [0, 6.35], [0, 0], width=0.1),
         Rect('F.CrtYd', [-cmargin, -moffset - cmargin], [l + cmargin, ph + cmargin - (moffset / 2)], width=0.05),
 
-        Line('F.SilkS', [-smargin, -smargin], [l + smargin - 1, -smargin]),
-        Line('F.SilkS', [l + smargin - 1, -smargin], [l + smargin, 1 - smargin]),
-        Line('F.SilkS', [l + smargin, 1 - smargin], [l + smargin, 6.35 + smargin]),
+        Line('F.SilkS', [-smargin, -smargin], [l - 1 + sloped_margin, -smargin]),
+        Line('F.SilkS', [l - 1 + sloped_margin, -smargin], [l + smargin, 1 - sloped_margin]),
+        Line('F.SilkS', [l + smargin, 1 - sloped_margin], [l + smargin, 6.35 + smargin]),
         Line('F.SilkS', [l + smargin, 6.35 + smargin], [-smargin, 6.35 + smargin]),
         Line('F.SilkS', [-smargin, 6.35 + smargin], [-smargin, -smargin]),
     ]

--- a/mta100/shape.py
+++ b/mta100/shape.py
@@ -33,6 +33,22 @@ class Line(Shape):
             (Symbol('uuid'), uuid),
         )
 
+def make_connected_lines(layer, points, width=0.2, loop=False):
+    if loop:
+        pairs = zip(points, points[1:] + [points[0]])
+    else:
+        pairs = zip(points, points[1:])
+    return [Line(layer, point, next, width) for point, next in pairs]
+
+def make_indexed_rect(layer, start, end):
+    return make_connected_lines('F.Fab',
+        [
+            [0, 0], [l - 1, 0],
+            [l, 1],
+            [l, 6.35],
+            [0, 6.35],
+        ], loop=True, width=0.1,
+    )
 
 class Circle(Shape):
     def __init__(self, layer, center, end, style=None):


### PR DESCRIPTION
This PR makes the following changes:
- Adds lines between the pads and the main rectangle on the 640455 part (the angled header)
- Adds a sloped angle to the silkscreen rectangle corner with the first pin, same as the sloped angle on `F.Fab`. The code now correctly calculates the coordinates of the sloped segment's endpoints so that the margin is correct (although it still *looks* off due to the different widths of the `F.Fab` and `F.SilkS` lines)
- Refactors the code a bit, adding a `make_connected_lines` function, which avoids specifying points twice

I'm sorry about including everything in one large PR: if you want to skip some of the changes, the commits should be well-defined enough to cherry-pick - for example, I'm not sure whether the lack of silkscreen sloped angle is intentional or not.